### PR TITLE
Remove "ADC hack"

### DIFF
--- a/rpipins/__main__.py
+++ b/rpipins/__main__.py
@@ -203,9 +203,6 @@ def styled(label, style, fg=None):
 def search(pin, highlight):
     if not highlight:
         return False
-    # Hack to make "--find adc" also find A0, A1, etc
-    if highlight.lower() == "adc":
-        highlight += "|a[0-9]"
     highlight = re.compile(highlight, re.I)
     # Match search term against pin label
     return re.search(highlight, pin) is not None


### PR DESCRIPTION
The Raspberry Pi doesn't have any ADC pins on the GPIO header. This was also causing false-positives for any pins that had been set to an alternate-function-mode.